### PR TITLE
Transaction's new Error State

### DIFF
--- a/Sources/CashUI/Model/CoreTransaction.swift
+++ b/Sources/CashUI/Model/CoreTransaction.swift
@@ -3,6 +3,7 @@ import Foundation
 import CashCore
 
 public enum CoreTransactionStatus: String, Codable {
+    // IMPORTANT: Do not change the values of the cases as User Defaults will cause exceptions if any objects were stored
     case VerifyPending = "New" // Nice to have.
     case SendPending = "Pending" // Note: Could be send from other wallet. After X time, this transaction may be cancelled if not sent
     case Awaiting = "Transaction Sent"
@@ -10,6 +11,7 @@ public enum CoreTransactionStatus: String, Codable {
     case Funded = "Funded" // It could take some time to be confirmed
     case Withdrawn = "Used"
     case Cancelled = "Cancelled"
+    case Error = "Error"
 
     static func transactionStatus(from status: CodeStatus) -> CoreTransactionStatus {
         switch status {
@@ -23,7 +25,19 @@ public enum CoreTransactionStatus: String, Codable {
             return .Withdrawn
         case .CANCELLED:
             return .Cancelled
+        case .ERROR:
+            return .Error
         }
+    }
+    
+    // Codable stores the rawValue of the enum in the UserDefaults, hence chaning the rawValue
+    // was not an option as retrieving from user defaults would cause an exception
+    // This is a helper variable to return the rawValue with some exceptions
+    public var displayValue: String {
+        if rawValue == "Cancelled" {
+            return "Expired"
+        }
+        return rawValue
     }
 }
 
@@ -71,6 +85,8 @@ public struct CoreTransaction: CustomStringConvertible, Codable, Equatable {
             return "85BB65"
         case .Cancelled:
             return "5e6fa5"
+        case .Error:
+            return "a55e6f"
         }
     }
     

--- a/Sources/CashUI/Model/CoreTransactionManager.swift
+++ b/Sources/CashUI/Model/CoreTransactionManager.swift
@@ -230,7 +230,7 @@ open class CoreTransactionManager {
             switch transaction.status {
             case .VerifyPending, .SendPending:
                 CoreTransactionManager.cancelPending(transaction)
-            case .Awaiting, .FundedNotConfirmed, .Funded, .Withdrawn, .Cancelled:
+            case .Awaiting, .FundedNotConfirmed, .Funded, .Withdrawn, .Cancelled, .Error:
                 CoreTransactionManager.poll(transaction)
             }
         }

--- a/Sources/CashUI/Model/WACTransaction.swift
+++ b/Sources/CashUI/Model/WACTransaction.swift
@@ -43,6 +43,8 @@ public struct WACTransaction: CustomStringConvertible, Codable, Equatable {
             return "85BB65"
         case .Cancelled:
             return "5e6fa5"
+        case .Error:
+            return "a55e6f"
         }
     }
     

--- a/Sources/CashUI/UI/OtherUI/ActivityTableViewCell.swift
+++ b/Sources/CashUI/UI/OtherUI/ActivityTableViewCell.swift
@@ -64,7 +64,7 @@ class ActivityTableViewCell: UITableViewCell {
             self.atmMachineAddressLabel.text = address.joined(separator: ", ")
         }
         self.amountLabel.text = (transaction.code?.btcAmount ?? "0") + " BTC"
-        self.fundedLabel.text = transaction.status.rawValue
+        self.fundedLabel.text = transaction.status.displayValue
         self.leftView.backgroundColor = UIColor.fromHex(transaction.color)
         self.dateLabel.text = Date().dateString(from: transaction.timestamp)
         self.timeLabel.text = Date().timeString(from: transaction.timestamp)

--- a/Sources/CashUI/UI/OtherUI/WithdrawalStatusViewController.swift
+++ b/Sources/CashUI/UI/OtherUI/WithdrawalStatusViewController.swift
@@ -90,7 +90,7 @@ class WithdrawalStatusViewController: ActionViewController {
         self.addressTitleLabel.isHidden = true
         
         self.stateLabel.isHidden = false
-        self.stateLabel.text = status.rawValue
+        self.stateLabel.text = status.displayValue
         
         self.redeemView.isHidden = true
         
@@ -105,7 +105,7 @@ class WithdrawalStatusViewController: ActionViewController {
             self.stateLabel.isHidden = true
             self.redeemView.isHidden = false
             break
-        case .Withdrawn, .Cancelled, .VerifyPending:
+        case .Withdrawn, .Cancelled, .VerifyPending, .Error:
             break
         case .SendPending:
             self.qrCodeImageView.isHidden = false


### PR DESCRIPTION
Add new Error Transaction state. Adds a new Transaction var displayName to be used instead of rawValue for UI display. This covers the case to change Cancelled to Expired